### PR TITLE
feat(telegram): split long messages before sending

### DIFF
--- a/hal/channels/telegram.py
+++ b/hal/channels/telegram.py
@@ -190,6 +190,37 @@ class TelegramChannel(BaseChannel):
             await self._app.shutdown()
             self._app = None
 
+    def _split_telegram_message(self, text: str, max_length: int = 4000) -> list[str]:
+        """
+        将长文本拆分为多个 Telegram 消息块。
+
+        策略（仿照 PR #694）：
+        1. 优先在换行符处拆分
+        2. 次选在空格处拆分
+        3. 如果没有好的分割点，强制在 max_length 处拆分
+        """
+        if len(text) <= max_length:
+            return [text]
+
+        chunks: list[str] = []
+        remaining = text
+
+        while len(remaining) > max_length:
+            split_pos = remaining.rfind("\n", 0, max_length + 1)
+            if split_pos <= 0:
+                split_pos = remaining.rfind(" ", 0, max_length + 1)
+            if split_pos <= 0:
+                split_pos = max_length
+
+            chunks.append(remaining[:split_pos])
+            remaining = remaining[split_pos:]
+            remaining = remaining.lstrip("\n ")
+
+        if remaining:
+            chunks.append(remaining)
+
+        return chunks
+
     async def send(self, msg: OutboundMessage) -> None:
         """Send a message through Telegram."""
         if not self._app:
@@ -200,20 +231,22 @@ class TelegramChannel(BaseChannel):
         self._stop_typing(msg.chat_id)
 
         try:
-            # chat_id should be the Telegram chat ID (integer)
             chat_id = int(msg.chat_id)
-            # Convert markdown to Telegram HTML
-            html_content = _markdown_to_telegram_html(msg.content)
-            await self._app.bot.send_message(chat_id=chat_id, text=html_content, parse_mode="HTML")
         except ValueError:
             logger.error(f"Invalid chat_id: {msg.chat_id}")
-        except Exception as e:
-            # Fallback to plain text if HTML parsing fails
-            logger.warning(f"HTML parse failed, falling back to plain text: {e}")
+            return
+
+        # Split markdown first, then convert each chunk to HTML to avoid breaking tags.
+        for chunk in self._split_telegram_message(msg.content):
             try:
-                await self._app.bot.send_message(chat_id=int(msg.chat_id), text=msg.content)
-            except Exception as e2:
-                logger.error(f"Error sending Telegram message: {e2}")
+                html_chunk = _markdown_to_telegram_html(chunk)
+                await self._app.bot.send_message(chat_id=chat_id, text=html_chunk, parse_mode="HTML")
+            except Exception as e:
+                logger.warning(f"HTML parse failed for one chunk, falling back to plain text: {e}")
+                try:
+                    await self._app.bot.send_message(chat_id=chat_id, text=chunk)
+                except Exception as e2:
+                    logger.error(f"Error sending Telegram message chunk: {e2}")
 
     async def _on_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command."""

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -12,6 +12,34 @@ from hal.channels.telegram import TelegramChannel, _markdown_to_telegram_html
 from hal.infra.config.schema import TelegramConfig
 
 
+
+def test_split_telegram_message_no_split() -> None:
+    ch = TelegramChannel(TelegramConfig(enabled=True, token="t"), MessageBus())
+    text = "hello"
+    assert ch._split_telegram_message(text) == [text]
+
+
+def test_split_telegram_message_long_text() -> None:
+    ch = TelegramChannel(TelegramConfig(enabled=True, token="t"), MessageBus())
+    text = "a" * 9001
+    chunks = ch._split_telegram_message(text, max_length=4000)
+
+    assert len(chunks) == 3
+    assert all(len(c) <= 4000 for c in chunks)
+    assert "".join(chunks) == text
+
+
+def test_split_telegram_message_prefers_newline_then_space() -> None:
+    ch = TelegramChannel(TelegramConfig(enabled=True, token="t"), MessageBus())
+
+    text_with_newline = "a" * 50 + "\n" + "b" * 50
+    chunks_newline = ch._split_telegram_message(text_with_newline, max_length=60)
+    assert chunks_newline == ["a" * 50, "b" * 50]
+
+    text_with_space = "a" * 50 + " " + "b" * 50
+    chunks_space = ch._split_telegram_message(text_with_space, max_length=60)
+    assert chunks_space == ["a" * 50, "b" * 50]
+
 def test_markdown_to_telegram_html_converts_and_escapes() -> None:
     md = (
         "# Title\n"
@@ -81,17 +109,19 @@ async def test_send_invalid_chat_id_is_ignored() -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_falls_back_to_plain_text_on_html_error() -> None:
+async def test_send_falls_back_to_plain_text_on_single_chunk_html_error() -> None:
     class DummyBot:
         def __init__(self):
             self.sent: list[tuple[int, str, str | None]] = []
+            self.html_calls = 0
 
         async def send_message(
             self, chat_id: int, text: str, parse_mode: str | None = None
         ) -> None:
-            # Simulate Telegram rejecting HTML
             if parse_mode == "HTML":
-                raise RuntimeError("bad html")
+                self.html_calls += 1
+                if self.html_calls == 1:
+                    raise RuntimeError("bad html")
             self.sent.append((chat_id, text, parse_mode))
 
     class DummyApp:
@@ -104,8 +134,46 @@ async def test_send_falls_back_to_plain_text_on_html_error() -> None:
     msg = OutboundMessage(channel="telegram", chat_id="123", content="**hi**")
     await ch.send(msg)
 
-    # First attempt raised, second attempt should succeed without parse_mode.
     assert ch._app.bot.sent == [(123, "**hi**", None)]
+
+
+@pytest.mark.asyncio
+async def test_send_multiple_chunks_calls_send_message_multiple_times() -> None:
+    class DummyBot:
+        def __init__(self):
+            self.sent: list[tuple[int, str, str | None]] = []
+
+        async def send_message(
+            self, chat_id: int, text: str, parse_mode: str | None = None
+        ) -> None:
+            self.sent.append((chat_id, text, parse_mode))
+
+    class DummyApp:
+        def __init__(self):
+            self.bot = DummyBot()
+
+    ch = TelegramChannel(TelegramConfig(enabled=True, token="t"), MessageBus())
+    ch._app = DummyApp()  # type: ignore[attr-defined]
+
+    msg = OutboundMessage(channel="telegram", chat_id="123", content=("a" * 4100))
+    await ch.send(msg)
+
+    assert len(ch._app.bot.sent) == 2
+    assert all(item[2] == "HTML" for item in ch._app.bot.sent)
+
+
+def test_split_then_html_keeps_tags_complete_per_chunk() -> None:
+    ch = TelegramChannel(TelegramConfig(enabled=True, token="t"), MessageBus())
+
+    md = "**bold** " * 700
+    chunks = ch._split_telegram_message(md, max_length=4000)
+    html_chunks = [_markdown_to_telegram_html(chunk) for chunk in chunks]
+
+    assert len(html_chunks) >= 2
+    for html in html_chunks:
+        assert html.count("<b>") == html.count("</b>")
+        assert html.count("<i>") == html.count("</i>")
+        assert html.count("<s>") == html.count("</s>")
 
 
 def test_get_extension_prefers_mime_type_mapping() -> None:


### PR DESCRIPTION
仿照 nanobot PR #694 实现 Telegram 长消息自动拆分功能。

## 变更内容
- 新增 `_split_telegram_message()` 方法，支持在换行符/空格处优先拆分
- 先拆分 markdown，逐段转为 HTML，避免切断 HTML 标签
- chunk 粒度错误处理，单个 chunk 失败不影响其他 chunks
- 全面测试覆盖（293 passed）

## 技术细节
- Telegram 限制：4096 字符/消息
- 拆分策略：换行符 > 空格 > 强制截断
- 保持原有的 HTML fallback 逻辑

## 测试
```bash
pytest tests/channels/test_telegram.py -v
# 13 passed
```

解决长消息发送时的 "Message is too long" 错误。